### PR TITLE
Extend configuration by default strategy

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,6 +8,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class Configuration implements ConfigurationInterface
 {
+    private const STRATEGIES = [
+        'identical',
+        'lowercase',
+    ];
+
     /** {@inheritdoc} */
     public function getConfigTreeBuilder(): TreeBuilder
     {
@@ -20,8 +25,16 @@ final class Configuration implements ConfigurationInterface
             $root = $builder->getRootNode();
         }
 
-        $root->children()->booleanNode('enum_name_type_mapping')
-            ->defaultValue(false);
+        $root
+            ->children()
+                ->booleanNode('enum_name_type_mapping')
+                    ->defaultValue(false)
+                ->end()
+                ->enumNode('default_strategy')
+                    ->values(self::STRATEGIES)
+                    ->defaultValue(self::STRATEGIES[0])
+                ->end()
+            ->end();
 
         $this->configureEnumNodes($root);
 
@@ -44,18 +57,14 @@ final class Configuration implements ConfigurationInterface
             )
             ->end();
         $dbalTypeProto
-            ->children()->scalarNode('class')
-            ->isRequired()
-            ->example('My\Enum');
-        $dbalTypeProto
-            ->children()->enumNode('strategy')
-            ->values(
-                [
-                    'lowercase',
-                    'identical'
-                ]
-            )
-            ->defaultValue('identical')
-        ;
+            ->children()
+                ->scalarNode('class')
+                    ->isRequired()
+                    ->example('My\Enum')
+                ->end()
+                ->enumNode('strategy')
+                    ->values(self::STRATEGIES)
+                ->end()
+            ->end();
     }
 }

--- a/src/DependencyInjection/LamodaEnumExtension.php
+++ b/src/DependencyInjection/LamodaEnumExtension.php
@@ -25,7 +25,7 @@ final class LamodaEnumExtension extends Extension
 
         foreach ($configs['dbal_types'] ?? [] as $name => $typeConfig) {
             $fqcn = $typeConfig['class'];
-            $strategy = $this->getStrategy($typeConfig['strategy'] ?? null);
+            $strategy = $this->getStrategy($typeConfig['strategy'] ?? $configs['default_strategy']);
             $typeInitializer->addMethodCall('initialize', [$name, $fqcn, $strategy, $configs['enum_name_type_mapping']]);
         }
     }

--- a/tests/Unit/DependencyInjection/LamodaEnumExtensionTest.php
+++ b/tests/Unit/DependencyInjection/LamodaEnumExtensionTest.php
@@ -73,4 +73,74 @@ final class LamodaEnumExtensionTest extends TestCase
         self::assertInstanceOf(Reference::class, $strat1);
         self::assertSame(LowercaseNamingStrategy::class, (string) $strat1);
     }
+
+    public function testExtensionLoadsConfigsWithDefaultStrategy(): void
+    {
+        $builder = new ContainerBuilder();
+        $extension = new LamodaEnumExtension();
+
+        $extension->load(
+            [
+                [
+                    'enum_name_type_mapping' => true,
+                    'default_strategy' => 'lowercase',
+                    'dbal_types' => [
+                        'type_1' => TestEnum::class,
+                        'type_2' => [
+                            'class' => TestEnum::class,
+                            'strategy' => 'identical',
+                        ],
+                    ],
+                ],
+            ],
+            $builder
+        );
+
+        $initDef = $builder->getDefinition(EnumTypeInitializer::class);
+        $calls = $initDef->getMethodCalls();
+
+        /** @var Reference $strat1 */
+        $strat1 = $calls[0][1][2];
+        self::assertInstanceOf(Reference::class, $strat1);
+        self::assertSame(LowercaseNamingStrategy::class, (string) $strat1);
+
+        /** @var Reference $strat1 */
+        $strat1 = $calls[1][1][2];
+        self::assertInstanceOf(Reference::class, $strat1);
+        self::assertSame(IdenticalNamingStrategy::class, (string) $strat1);
+    }
+
+    public function testExtensionLoadsConfigsWithoutStrategies(): void
+    {
+        $builder = new ContainerBuilder();
+        $extension = new LamodaEnumExtension();
+
+        $extension->load(
+            [
+                [
+                    'enum_name_type_mapping' => true,
+                    'dbal_types' => [
+                        'type_1' => TestEnum::class,
+                        'type_2' => [
+                            'class' => TestEnum::class,
+                        ],
+                    ],
+                ],
+            ],
+            $builder
+        );
+
+        $initDef = $builder->getDefinition(EnumTypeInitializer::class);
+        $calls = $initDef->getMethodCalls();
+
+        /** @var Reference $strat1 */
+        $strat1 = $calls[0][1][2];
+        self::assertInstanceOf(Reference::class, $strat1);
+        self::assertSame(IdenticalNamingStrategy::class, (string)$strat1);
+
+        /** @var Reference $strat1 */
+        $strat1 = $calls[1][1][2];
+        self::assertInstanceOf(Reference::class, $strat1);
+        self::assertSame(IdenticalNamingStrategy::class, (string)$strat1);
+    }
 }


### PR DESCRIPTION
Bring possibility to configurate default strategy value.
Example:
```
lamoda_enum:
  enum_name_type_mapping: true
  default_strategy: lowercase
  dbal_types:
    contract_type_enum:
      class: Platform\Enum\ContractTypeEnum
      strategy: identical
    exchange_system_enum:
      class: Platform\Enum\ExchangeSystemEnum
```
tests are also provided.